### PR TITLE
Added formatted item values to database objects

### DIFF
--- a/public/scripts/admin/main.js
+++ b/public/scripts/admin/main.js
@@ -13,6 +13,6 @@ function processFile(event) {
   var collect = db.collection("all-items");
   for (let item of list) {
     var keyObj = buildKey(item.name);
-    writeItemToDatabase(item, keyObj));
+    writeItemToDatabase(item, keyObj);
   }
 }

--- a/public/scripts/shared/database/db-write.js
+++ b/public/scripts/shared/database/db-write.js
@@ -3,6 +3,7 @@ function writeItemToDatabase(item, keyObject) {
   var itemVal = item.value.replace(/,|( gp)/g,"");
   if (keyObject.subtype === '') {
     dbObj.value = itemVal;
+    dbObj.displayValue = item.value;
     dbObj.name = item.name;
   } else {
     dbObj.name = keyObject.trimmedName;
@@ -13,7 +14,7 @@ function writeItemToDatabase(item, keyObject) {
     return false;  
   });
   if (keyObject.subtype !== '') {
-    var subObj = {name: item.name, value: itemVal};
+    var subObj = {name: item.name, value: itemVal, displayValue: item.value};
     db.collection("all-items/" + keyObject.key + "/subtypes").doc(keyObject.subtype).set(subObj).then(function() {
       return true;
     }).catch(function() {


### PR DESCRIPTION
For simplicity in both displaying item values and calculating totals, I've added a field called "displayValue" to the item objects in the database. This simply contains the item's value in the format originally scraped from d20PFSRD, i. e. "24,000 gp" in addition to "24000".